### PR TITLE
cpu/esp32: esp_now_netdev changes

### DIFF
--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -17,8 +17,6 @@
  * @author      Timo Rothenpieler <timo.rothenpieler@uni-bremen.de>
  */
 
-#define ENABLE_DEBUG (0)
-#include "debug.h"
 #include "log.h"
 #include "tools.h"
 
@@ -43,10 +41,13 @@
 #include "esp_now_params.h"
 #include "esp_now_netdev.h"
 
-#define ESP_NOW_UNICAST          1
+#define ENABLE_DEBUG (0)
+#include "debug.h"
 
-#define ESP_NOW_WIFI_STA         1
-#define ESP_NOW_WIFI_SOFTAP      2
+#define ESP_NOW_UNICAST          (1)
+
+#define ESP_NOW_WIFI_STA         (1)
+#define ESP_NOW_WIFI_SOFTAP      (2)
 #define ESP_NOW_WIFI_STA_SOFTAP  (ESP_NOW_WIFI_STA + ESP_NOW_WIFI_SOFTAP)
 
 #define ESP_NOW_AP_PREFIX        "RIOT_ESP_"

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -94,6 +94,16 @@ static bool _esp_now_add_peer(uint8_t* bssid, uint8_t channel, uint8_t* key)
 static wifi_ap_record_t* aps = NULL;
 static uint32_t aps_size = 0;
 
+static const wifi_scan_config_t scan_cfg = {
+        .ssid = NULL,
+        .bssid = NULL,
+        .channel = ESP_NOW_CHANNEL,
+        .show_hidden = true,
+        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+        .scan_time.active.min = 0,
+        .scan_time.active.max = 120 /* TODO tune value */
+};
+
 static void IRAM_ATTR esp_now_scan_peers_done(void)
 {
     mutex_lock(&_esp_now_dev.dev_lock);
@@ -158,16 +168,6 @@ static void IRAM_ATTR esp_now_scan_peers_done(void)
 static void esp_now_scan_peers_start(void)
 {
     DEBUG("%s\n", __func__);
-
-    wifi_scan_config_t scan_cfg = {
-        .ssid = NULL,
-        .bssid = NULL,
-        .channel = esp_now_params.channel,
-        .show_hidden = true,
-        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
-        .scan_time.active.min = 0,
-        .scan_time.active.max = 120 /* TODO tune value */
-    };
 
     esp_wifi_scan_start(&scan_cfg, false);
 }

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -431,8 +431,9 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
     dev->netdev.driver = &_esp_now_driver;
 
     /* initialize netdev data structure */
-    dev->peers_all = 0;
-    dev->peers_enc = 0;
+    dev->recv_event = false;
+    dev->scan_event = false;
+
     mutex_init(&dev->dev_lock);
 
     /* initialize ESP-NOW and register callback functions */

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -512,7 +512,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     iolist = iolist->iol_next;
 
     DEBUG("%s: send %u byte\n", __func__, (unsigned)iolist->iol_len);
-#if defined(MODULE_OD) && ENABLE_DEBUG
+#if MODULE_OD && ENABLE_DEBUG
     od_hex_dump(iolist->iol_base, iolist->iol_len, OD_WIDTH_DEFAULT);
 #endif
 
@@ -614,7 +614,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         DEBUG("%s: received %d byte from %02x:%02x:%02x:%02x:%02x:%02x\n",
               __func__, size - ESP_NOW_ADDR_LEN,
               mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-#if defined(MODULE_OD) && ENABLE_DEBUG
+#if MODULE_OD && ENABLE_DEBUG
         od_hex_dump(buf + ESP_NOW_ADDR_LEN, size - ESP_NOW_ADDR_LEN, OD_WIDTH_DEFAULT);
 #endif
 

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -527,9 +527,18 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the packet to the peer(s) mac address */
     if (esp_now_send(_esp_now_dst, iolist->iol_base, iolist->iol_len) == 0) {
+        /**
+         * The function esp_now_send_cb does seems sporadically not to be
+         * called and _esp_now_sending remains set. This locks the entire
+         * netdev driver. The netdev driver also works without the feedback
+         * of the transmission success. In the case of a lost message, it
+         * can rely on the error control of the upper classes.
+         */
+#if 0
         while (_esp_now_sending > 0) {
             thread_yield_higher();
         }
+#endif
 
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.tx_bytes += iolist->iol_len;

--- a/cpu/esp32/esp-now/esp_now_netdev.h
+++ b/cpu/esp32/esp-now/esp_now_netdev.h
@@ -88,10 +88,10 @@ typedef struct
     gnrc_nettype_t proto;            /**< protocol for upper layer */
 #endif
 
-    uint8_t peers_all;               /**< number of peers reachable */
-    uint8_t peers_enc;               /**< number of encrypted peers */
-
     mutex_t dev_lock;                /**< device is already in use */
+
+    bool recv_event;                 /**< ESP-NOW frame received */
+    bool scan_event;                 /**< ESP-NOW peers have to be scannged */
 
 } esp_now_netdev_t;
 

--- a/cpu/esp32/esp-now/esp_now_netif.c
+++ b/cpu/esp32/esp-now/esp_now_netif.c
@@ -240,8 +240,8 @@ void auto_init_esp_now(void)
         LOG_ERROR("[auto_init_netif] error initializing esp_now\n");
     } else {
         esp_now_dev->netif =
-            gnrc_netif_esp_now_create(_esp_now_stack,
-                                      ESP_NOW_STACKSIZE, ESP_NOW_PRIO,
+            gnrc_netif_esp_now_create(_esp_now_stack, sizeof(_esp_now_stack),
+                                      ESP_NOW_PRIO,
                                       "net-esp-now",
                                       &esp_now_dev->netdev);
     }


### PR DESCRIPTION
### Contribution description

This PR contains the following changes:
- `_esp_now_sending` isn't used any longer in `_send` to wait for feedback whether the message has been sent from `esp_now_send_cb`. The function esp_now_send_cb does seems sporadically not to be 
 called and `_esp_now_sending` remains set. This locks the entire netdev driver.
- Defining `scan_cfg` as a static const variable outside the `esp_now_scan_peers_start` function moves the variable from the thread stack to the `.rodata` segment in flash. Increases the stability at high network load.
- Changes required to get `esp_now_netdev` multicast version working (still unstable). This has the advantage that there is no need to scan and add the peers. The `net-esp-now-event` thread is then obsolete.
- Some small cleanup like shifting `ENABLE_DEBUG` and `#include "debug.h"` to the end of includes and using `#if MODULE_XYZ` instead of `#if defined(MODULE_XYZ)`
- Extra thread `net-esp-now-event` in ESP-NOW unicast approach removed. The timer event for periodic peer scan is now handled as netdev event by callback from `esp_now` netif thread.

### Testing procedure

Flash `examples/gnrc_examples` to at least two ESP32 boards and ping them with stressy pings:
```
ping6 1000 <ipv6_address> 1232 50
```
### Issues/PRs references
