### PR TITLE
cpu/esp32: esp_now_netdev stability improvements

### DIFF
--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -507,24 +507,16 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the packet to the peer(s) mac address */
     if (esp_now_send(_esp_now_dst, iolist->iol_base, iolist->iol_len) == 0) {
-        /**
-         * The function esp_now_send_cb does seems sporadically not to be
-         * called and _esp_now_sending remains set. This locks the entire
-         * netdev driver. The netdev driver also works without the feedback
-         * of the transmission success. In the case of a lost message, it
-         * can rely on the error control of the upper classes.
-         */
-#if 0
         while (_esp_now_sending > 0) {
             thread_yield_higher();
         }
-#endif
 
 #ifdef MODULE_NETSTATS_L2
         netdev->stats.tx_bytes += iolist->iol_len;
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
 #endif
 
+printf("D");
         mutex_unlock(&dev->dev_lock);
         return iolist->iol_len;
     }

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -41,7 +41,7 @@
 #include "esp_now_params.h"
 #include "esp_now_netdev.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG             (0)
 #include "debug.h"
 
 #define ESP_NOW_UNICAST          (1)
@@ -142,9 +142,8 @@ static void IRAM_ATTR esp_now_scan_peers_done(void)
         /* iterate over APs records */
         for (uint16_t i = 0; i < ap_num; i++) {
 
-            /* check whether the AP is an ESP_NOW node which is not already a peer */
-            if (strncmp((char*)aps[i].ssid, ESP_NOW_AP_PREFIX, ESP_NOW_AP_PREFIX_LEN) == 0 &&
-                !esp_now_is_peer_exist(aps[i].bssid)) {
+            /* check whether the AP is an ESP_NOW node */
+            if (strncmp((char*)aps[i].ssid, ESP_NOW_AP_PREFIX, ESP_NOW_AP_PREFIX_LEN) == 0) {
                 /* add the AP as peer */
                 _esp_now_add_peer(aps[i].bssid, aps[i].primary, esp_now_params.key);
             }
@@ -440,7 +439,7 @@ esp_now_netdev_t *netdev_esp_now_setup(void)
     _esp_now_scan_peers_timer.arg = dev;
 
     /* execute the first scan */
-    esp_now_scan_peers_done();
+    esp_now_scan_peers_start();
 
 #else /* ESP_NOW_UNICAST */
     bool res = _esp_now_add_peer(_esp_now_mac, esp_now_params.channel,

--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -520,7 +520,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
 #endif
 
-printf("D");
         mutex_unlock(&dev->dev_lock);
         return iolist->iol_len;
     }

--- a/cpu/esp32/esp-now/esp_now_netdev.h
+++ b/cpu/esp32/esp-now/esp_now_netdev.h
@@ -89,6 +89,7 @@ typedef struct
 #endif
 
     mutex_t dev_lock;                /**< device is already in use */
+    mutex_t rx_lock;                 /**< rx_buf handling in progress */
 
     bool recv_event;                 /**< ESP-NOW frame received */
     bool scan_event;                 /**< ESP-NOW peers have to be scannged */


### PR DESCRIPTION
### Contribution description

This PR contains the following changes:

- Since the locking problem is solved, `_esp_now_sending` should be used again to avoid that the sending thread is trying to send faster than the WiFi system can handle send requests.
From [ESP-IDF reference](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/network/esp_now.html?highlight=esp_now_register_send_cb#_CPPv224esp_now_register_send_cb17esp_now_send_cb_t): _Note that too short interval between sending two ESP-NOW datas may lead to disorder of sending callback function. So, it is recommended that sending the next ESP-NOW data after the sending callback function of previous sending has returned._
- A separate mutex for the receiving part of `esp_now_netdev` was introduced to avoid that the high priority `wifi` thread tries to change the ringbufferon receiption of a frame while the low priority `esp_now_netif` thread is reading the ringbuffer.

### Testing procedure

Flash `examples/gnrc_examples` to at least two ESP32 boards and ping them with stressy pings:
```
ping6 1000 <ipv6_address> 1232 50
```
### Issues/PRs references

The changes were made as follow ups to #PR1