### PR TITLE
cpu/esp32: esp_now_netdev stability improvement

### DIFF
--- a/cpu/esp32/esp-now/esp_now_netdev.c
+++ b/cpu/esp32/esp-now/esp_now_netdev.c
@@ -498,8 +498,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     od_hex_dump(iolist->iol_base, iolist->iol_len, OD_WIDTH_DEFAULT);
 #endif
 
-    _esp_now_sending = 1;
-
     if (_esp_now_dst) {
         DEBUG("%s: send to esp_now addr %02x:%02x:%02x:%02x:%02x:%02x\n", __func__,
               _esp_now_dst[0], _esp_now_dst[1], _esp_now_dst[2],
@@ -510,6 +508,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the packet to the peer(s) mac address */
     if (esp_now_send(_esp_now_dst, iolist->iol_base, iolist->iol_len) == 0) {
+        _esp_now_sending = 1;
         while (_esp_now_sending > 0) {
             thread_yield_higher();
         }


### PR DESCRIPTION
### Contribution description

`_esp_now_sending` should only be set if `esp_now_send` returns with success. In case of error, `esp_now_send_cb` is not called and the `esp_now_netdev` driver locks.

### Testing procedure
 
Flash `examples/gnrc_examples` to at least two ESP32 boards and ping them with stressy pings:
```
ping6 1000 <ipv6_address> 1232 50
```

### Issues/PRs references

The changes were made as follow ups to #PR2
